### PR TITLE
Make plan images larger and fully visible on search result cards

### DIFF
--- a/src/components/CustomHits.tsx
+++ b/src/components/CustomHits.tsx
@@ -22,7 +22,7 @@ function CustomHits({ className }: CustomHitsProps) {
   return (
     <div
       className={cn(
-        "grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3",
+        "grid grid-cols-1 gap-5 sm:grid-cols-2",
         className
       )}
     >

--- a/src/components/FloorPlanCard.tsx
+++ b/src/components/FloorPlanCard.tsx
@@ -89,7 +89,7 @@ function FloorPlanCard({ hit, sendEvent, className }: FloorPlanCardProps) {
         <div
           className={cn(
             "relative overflow-hidden",
-            "aspect-[4/3]",
+            "aspect-[1/1]",
             "max-sm:aspect-auto max-sm:h-36 max-sm:w-36 max-sm:flex-none"
           )}
         >
@@ -103,7 +103,7 @@ function FloorPlanCard({ hit, sendEvent, className }: FloorPlanCardProps) {
           ) : (
             <img
               alt={altText}
-              className="h-full w-full object-cover transition-transform duration-500 ease-out group-hover:scale-105"
+              className="h-full w-full object-contain transition-transform duration-500 ease-out group-hover:scale-105"
               loading="lazy"
               onError={() => setImageError(true)}
               src={hit.image}


### PR DESCRIPTION
- Change image fit from object-cover to object-contain to show full plan
- Increase image aspect ratio to 1:1 for more detail visibility
- Reduce search grid to 2 columns max for larger card sizes