### PR TITLE
Extract ZoomableImage component and refine search UI

### DIFF
--- a/src/components/CustomPagination.tsx
+++ b/src/components/CustomPagination.tsx
@@ -10,19 +10,23 @@ import { cn } from "@/lib/utils";
 
 interface PaginationItemProps extends React.ComponentProps<typeof Button> {
   href?: string;
+  isActive?: boolean;
   isDisabled?: boolean;
   onClick?: (event: React.MouseEvent) => void;
 }
 
 function PaginationItem({
+  isActive,
   isDisabled,
   href,
   onClick,
   className,
   ...props
 }: PaginationItemProps) {
+  const variant = isActive ? "default" : "outline";
   const buttonClasses = cn(
-    "min-w-[2.5rem] transition-colors hover:bg-accent hover:text-accent-foreground",
+    "min-w-[2.5rem] transition-colors",
+    !isActive && "hover:bg-accent hover:text-accent-foreground",
     className
   );
 
@@ -32,7 +36,7 @@ function PaginationItem({
         className={buttonClasses}
         disabled
         size="sm"
-        variant="outline"
+        variant={variant}
         {...props}
       />
     );
@@ -44,7 +48,7 @@ function PaginationItem({
         asChild
         className={buttonClasses}
         size="sm"
-        variant="outline"
+        variant={variant}
         {...props}
       >
         <a
@@ -69,7 +73,7 @@ function PaginationItem({
       className={buttonClasses}
       onClick={onClick}
       size="sm"
-      variant="outline"
+      variant={variant}
       {...props}
     />
   );
@@ -178,15 +182,13 @@ function CustomPagination({ className }: CustomPaginationProps) {
       <div className="flex items-center gap-2">
         {pages.map((page) => {
           const label = page + 1;
+          const isActive = currentRefinement === page;
           return (
             <PaginationItem
-              aria-current={currentRefinement === page ? "page" : undefined}
+              aria-current={isActive ? "page" : undefined}
               aria-label={`Page ${label}`}
-              className={cn(
-                currentRefinement === page &&
-                  "bg-primary text-primary-foreground"
-              )}
               href={createURL(page)}
+              isActive={isActive}
               isDisabled={false}
               key={page}
               onClick={() => handlePageChange(page)}

--- a/src/components/CustomRangeInput.tsx
+++ b/src/components/CustomRangeInput.tsx
@@ -2,7 +2,7 @@ import { X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useInstantSearch, useRange } from "react-instantsearch";
 import { Button } from "@/components/ui/button";
-import { Slider } from "@/components/ui/slider";
+import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
 interface CustomRangeInputProps {
@@ -21,7 +21,6 @@ function CustomRangeInput({
   const { setIndexUiState, indexUiState } = useInstantSearch();
   const { refine } = useRange({ attribute });
 
-  // Get current range from URL state if it exists
   const currentRange = indexUiState.range?.[attribute];
   const currentMin = currentRange
     ? Number(String(currentRange).split(":")[0])
@@ -30,28 +29,35 @@ function CustomRangeInput({
     ? Number(String(currentRange).split(":")[1])
     : undefined;
 
-  const [localRange, setLocalRange] = useState<[number, number]>([
-    currentMin !== undefined && !Number.isNaN(currentMin) ? currentMin : min,
-    currentMax !== undefined && !Number.isNaN(currentMax) ? currentMax : max,
-  ]);
+  const [minInput, setMinInput] = useState<string>(
+    currentMin !== undefined && !Number.isNaN(currentMin)
+      ? String(currentMin)
+      : ""
+  );
+  const [maxInput, setMaxInput] = useState<string>(
+    currentMax !== undefined && !Number.isNaN(currentMax)
+      ? String(currentMax)
+      : ""
+  );
 
   const isActive = currentRange !== undefined;
+  const step = attribute === "sqft" ? 100 : 1;
 
-  // Sync local state with external changes
+  // Sync inputs with external state changes (Reset All, saved searches, etc.)
   useEffect(() => {
     if (currentRange) {
       const parts = String(currentRange).split(":");
       const newMin = Number(parts[0]);
       const newMax = Number(parts[1]);
       if (!(Number.isNaN(newMin) || Number.isNaN(newMax))) {
-        setLocalRange([newMin, newMax]);
+        setMinInput(String(newMin));
+        setMaxInput(String(newMax));
       }
     } else {
-      setLocalRange([min, max]);
+      setMinInput("");
+      setMaxInput("");
     }
-  }, [currentRange, min, max]);
-
-  const step = attribute === "sqft" ? 100 : 1;
+  }, [currentRange]);
 
   const updateRange = useCallback(
     (startValue: number | undefined, endValue: number | undefined) => {
@@ -79,57 +85,98 @@ function CustomRangeInput({
     [attribute, setIndexUiState, refine, min, max]
   );
 
-  const handleValueCommit = (values: number[]) => {
-    const [newMin, newMax] = values;
-    if (newMin === min && newMax === max) {
+  const commit = useCallback(() => {
+    const parsedMin = minInput === "" ? undefined : Number(minInput);
+    const parsedMax = maxInput === "" ? undefined : Number(maxInput);
+
+    if (
+      (parsedMin !== undefined && Number.isNaN(parsedMin)) ||
+      (parsedMax !== undefined && Number.isNaN(parsedMax))
+    ) {
+      return;
+    }
+
+    if (parsedMin === undefined && parsedMax === undefined) {
+      updateRange(undefined, undefined);
+      return;
+    }
+
+    let finalMin = Math.max(min, Math.min(parsedMin ?? min, max));
+    let finalMax = Math.max(min, Math.min(parsedMax ?? max, max));
+    if (finalMin > finalMax) {
+      [finalMin, finalMax] = [finalMax, finalMin];
+    }
+
+    setMinInput(String(finalMin));
+    setMaxInput(String(finalMax));
+
+    if (finalMin === min && finalMax === max) {
       updateRange(undefined, undefined);
     } else {
-      updateRange(newMin, newMax);
+      updateRange(finalMin, finalMax);
     }
-  };
+  }, [minInput, maxInput, min, max, updateRange]);
 
   const handleClear = () => {
-    setLocalRange([min, max]);
+    setMinInput("");
+    setMaxInput("");
     updateRange(undefined, undefined);
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.currentTarget.blur();
+    }
+  };
+
+  const minPlaceholder =
+    attribute === "sqft" ? min.toLocaleString() : String(min);
+  const maxPlaceholder =
+    attribute === "sqft" ? max.toLocaleString() : String(max);
+
   return (
-    <div className={cn("space-y-3", className)}>
-      <div className="flex items-center gap-2">
-        <Slider
-          className="flex-1"
-          max={max}
-          min={min}
-          onValueChange={(values) => setLocalRange(values as [number, number])}
-          onValueCommit={handleValueCommit}
-          step={step}
-          value={localRange}
-        />
-        {isActive && (
-          <Button
-            className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
-            onClick={handleClear}
-            size="icon"
-            type="button"
-            variant="ghost"
-          >
-            <X className="h-4 w-4" />
-            <span className="sr-only">Clear range</span>
-          </Button>
-        )}
-      </div>
-      <div className="flex justify-between text-muted-foreground text-xs">
-        <span>
-          {attribute === "sqft"
-            ? localRange[0].toLocaleString()
-            : localRange[0]}
-        </span>
-        <span>
-          {attribute === "sqft"
-            ? localRange[1].toLocaleString()
-            : localRange[1]}
-        </span>
-      </div>
+    <div className={cn("flex items-center gap-2", className)}>
+      <Input
+        aria-label="Minimum"
+        className="h-8"
+        inputMode="numeric"
+        min={min}
+        onBlur={commit}
+        onChange={(e) => setMinInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={minPlaceholder}
+        step={step}
+        type="number"
+        value={minInput}
+      />
+      <span aria-hidden="true" className="text-muted-foreground text-sm">
+        –
+      </span>
+      <Input
+        aria-label="Maximum"
+        className="h-8"
+        inputMode="numeric"
+        max={max}
+        onBlur={commit}
+        onChange={(e) => setMaxInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={maxPlaceholder}
+        step={step}
+        type="number"
+        value={maxInput}
+      />
+      {isActive && (
+        <Button
+          className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
+          onClick={handleClear}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          <X className="h-4 w-4" />
+          <span className="sr-only">Clear range</span>
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/components/CustomSortBy.tsx
+++ b/src/components/CustomSortBy.tsx
@@ -1,7 +1,9 @@
 // src/components/CustomSortBy.tsx
 
+import { X } from "lucide-react";
 import { useSortBy } from "react-instantsearch";
 import Select from "react-select";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface SortOption {
@@ -10,11 +12,12 @@ interface SortOption {
 }
 
 interface CustomSortByProps {
+  baseIndex: string;
   className?: string;
   items: SortOption[];
 }
 
-function CustomSortBy({ items, className }: CustomSortByProps) {
+function CustomSortBy({ baseIndex, items, className }: CustomSortByProps) {
   const { currentRefinement, refine, canRefine } = useSortBy({
     items,
   });
@@ -23,60 +26,77 @@ function CustomSortBy({ items, className }: CustomSortByProps) {
     return null;
   }
 
-  // Find the current option to set as default value
+  // If the current sort is the base index, it won't be in items — fall back to
+  // a null value so react-select shows the placeholder instead of items[0].
   const currentOption =
-    items.find((item) => item.value === currentRefinement) || items[0];
+    items.find((item) => item.value === currentRefinement) ?? null;
+  const isActive = currentOption !== null;
 
   return (
-    <div className={cn("w-[200px]", className)}>
-      <Select
-        classNamePrefix="sort-select"
-        classNames={{
-          control: () =>
-            "!bg-background !border-border hover:!border-border !min-h-[36px] !shadow-none rounded-md",
-          menu: () =>
-            "!bg-background !border !border-border !shadow-md rounded-xl z-[100]",
-          option: (state) =>
-            cn(
-              "cursor-pointer px-3",
-              state.isSelected && "!bg-primary !text-primary-foreground",
-              state.isFocused && !state.isSelected && "!bg-accent",
-              "hover:!bg-accent"
-            ),
-          singleValue: () => "!text-foreground",
-          dropdownIndicator: () =>
-            "!text-muted-foreground hover:!text-foreground",
-          indicatorSeparator: () => "!bg-border",
-          input: () => "!text-foreground",
-          placeholder: () => "!text-muted-foreground",
+    <div className={cn("flex items-center gap-1", className)}>
+      <div className="w-[200px]">
+        <Select
+          classNamePrefix="sort-select"
+          classNames={{
+            control: () =>
+              "!bg-background !border-border hover:!border-border !min-h-[36px] !shadow-none rounded-md",
+            menu: () =>
+              "!bg-background !border !border-border !shadow-md rounded-xl z-[100]",
+            option: (state) =>
+              cn(
+                "cursor-pointer px-3",
+                state.isSelected && "!bg-primary !text-primary-foreground",
+                state.isFocused && !state.isSelected && "!bg-accent",
+                "hover:!bg-accent"
+              ),
+            singleValue: () => "!text-foreground",
+            dropdownIndicator: () =>
+              "!text-muted-foreground hover:!text-foreground",
+            indicatorSeparator: () => "!bg-border",
+            input: () => "!text-foreground",
+            placeholder: () => "!text-muted-foreground",
 
-          noOptionsMessage: () => "!text-muted-foreground py-2 px-3",
-          loadingMessage: () => "!text-muted-foreground py-2 px-3",
-        }}
-        isDisabled={!canRefine}
-        isSearchable={false}
-        menuPlacement="auto"
-        onChange={(option) => option && refine(option.value)}
-        options={items}
-        styles={{
-          // Only keep styles that can't be handled by Tailwind
-          control: (base) => ({
-            ...base,
-            backgroundColor: "transparent",
-            borderColor: "transparent",
-          }),
-          menu: (base) => ({
-            ...base,
-            backgroundColor: "transparent",
-            borderColor: "transparent",
-          }),
-          option: (base) => ({
-            ...base,
-            backgroundColor: "transparent",
-          }),
-        }}
-        value={currentOption}
-      />
+            noOptionsMessage: () => "!text-muted-foreground py-2 px-3",
+            loadingMessage: () => "!text-muted-foreground py-2 px-3",
+          }}
+          isDisabled={!canRefine}
+          isSearchable={false}
+          menuPlacement="auto"
+          onChange={(option) => option && refine(option.value)}
+          options={items}
+          placeholder="Sort by..."
+          styles={{
+            // Only keep styles that can't be handled by Tailwind
+            control: (base) => ({
+              ...base,
+              backgroundColor: "transparent",
+              borderColor: "transparent",
+            }),
+            menu: (base) => ({
+              ...base,
+              backgroundColor: "transparent",
+              borderColor: "transparent",
+            }),
+            option: (base) => ({
+              ...base,
+              backgroundColor: "transparent",
+            }),
+          }}
+          value={currentOption}
+        />
+      </div>
+      {isActive && (
+        <Button
+          aria-label="Clear sort"
+          className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
+          onClick={() => refine(baseIndex)}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/components/FloorPlanCard.tsx
+++ b/src/components/FloorPlanCard.tsx
@@ -33,6 +33,12 @@ function FloorPlanCard({ hit, sendEvent, className }: FloorPlanCardProps) {
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
 
+    sessionStorage.setItem(
+      "lastSearchUrl",
+      window.location.pathname + window.location.search
+    );
+    sessionStorage.setItem("pendingScrollToPlan", hit.objectID);
+
     if (sendEvent) {
       sendEvent({
         eventName: "click",

--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -1,10 +1,4 @@
-import {
-  ChevronLeft,
-  ChevronRight,
-  ImageOff,
-  ZoomIn,
-  ZoomOut,
-} from "lucide-react";
+import { ChevronLeft, ChevronRight, ImageOff } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -14,6 +8,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
+import ZoomableImage from "./ZoomableImage";
 
 interface ImageGalleryProps {
   images: Array<{ url: string }>;
@@ -26,7 +21,6 @@ export default function ImageGallery({
 }: ImageGalleryProps) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [lightboxOpen, setLightboxOpen] = useState(false);
-  const [zoomed, setZoomed] = useState(false);
   const [errorImages, setErrorImages] = useState<Set<string>>(new Set());
 
   const touchStartX = useRef<number | null>(null);
@@ -183,7 +177,7 @@ export default function ImageGallery({
 
       {/* Lightbox */}
       <Dialog onOpenChange={setLightboxOpen} open={lightboxOpen}>
-        <DialogContent className="flex h-[95vh] max-h-[95vh] w-[95vw] max-w-[95vw] flex-col items-center justify-center bg-black/95 p-0">
+        <DialogContent className="flex h-[95vh] max-h-[95vh] w-[95vw] max-w-[95vw] flex-col bg-black/95 p-0">
           <DialogTitle className="sr-only">
             {planNumber} - Image {selectedIndex + 1}
           </DialogTitle>
@@ -191,22 +185,7 @@ export default function ImageGallery({
             Full-screen view of floor plan image
           </DialogDescription>
 
-          {/* Zoom toggle */}
-          <div className="absolute top-4 right-14 z-10">
-            <Button
-              onClick={() => setZoomed((z) => !z)}
-              size="icon"
-              variant="ghost"
-            >
-              {zoomed ? (
-                <ZoomOut className="h-5 w-5 text-white" />
-              ) : (
-                <ZoomIn className="h-5 w-5 text-white" />
-              )}
-            </Button>
-          </div>
-
-          {/* Image */}
+          {/* Image with zoom controls — fills the dialog */}
           {currentImageHasError ? (
             <div className="flex h-full w-full flex-col items-center justify-center">
               <ImageOff className="h-16 w-16 text-muted-foreground" />
@@ -215,23 +194,11 @@ export default function ImageGallery({
               </p>
             </div>
           ) : (
-            <button
-              className="flex h-full w-full items-center justify-center overflow-auto border-none bg-transparent p-0"
-              onClick={() => setZoomed((z) => !z)}
-              type="button"
-            >
-              <img
-                alt={`${planNumber} - ${selectedIndex + 1} of ${images.length}`}
-                className={cn(
-                  "max-h-full transition-transform duration-200",
-                  zoomed
-                    ? "scale-150 cursor-zoom-out"
-                    : "scale-100 cursor-zoom-in"
-                )}
-                onError={() => handleImageError(currentImage)}
-                src={currentImage}
-              />
-            </button>
+            <ZoomableImage
+              alt={`${planNumber} - ${selectedIndex + 1} of ${images.length}`}
+              key={currentImage}
+              src={currentImage}
+            />
           )}
 
           {/* Navigation arrows */}

--- a/src/components/ListHits.tsx
+++ b/src/components/ListHits.tsx
@@ -82,15 +82,24 @@ export default function ListHits({ className }: ListHitsProps) {
             const targetUrl = isMasterRoute
               ? `/master/plan/${hit.objectID}`
               : `/plan/${hit.objectID}`;
+            const goToPlan = () => {
+              sessionStorage.setItem(
+                "lastSearchUrl",
+                window.location.pathname + window.location.search
+              );
+              sessionStorage.setItem("pendingScrollToPlan", hit.objectID);
+              navigate(targetUrl);
+            };
             return (
               <TableRow
                 className="cursor-pointer focus-visible:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                id={hit.objectID}
                 key={hit.objectID}
-                onClick={() => navigate(targetUrl)}
+                onClick={goToPlan}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
-                    navigate(targetUrl);
+                    goToPlan();
                   }
                 }}
                 role="link"

--- a/src/components/MobileSortButton.tsx
+++ b/src/components/MobileSortButton.tsx
@@ -5,6 +5,7 @@ import { Button } from "./ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
@@ -13,10 +14,14 @@ import {
 } from "./ui/dropdown-menu";
 
 interface MobileSortButtonProps {
+  baseIndex: string;
   sortItems: SortItem[];
 }
 
-export default function MobileSortButton({ sortItems }: MobileSortButtonProps) {
+export default function MobileSortButton({
+  baseIndex,
+  sortItems,
+}: MobileSortButtonProps) {
   const { currentRefinement, refine, canRefine } = useSortBy({
     items: sortItems,
   });
@@ -27,6 +32,7 @@ export default function MobileSortButton({ sortItems }: MobileSortButtonProps) {
 
   const currentLabel =
     sortItems.find((item) => item.value === currentRefinement)?.label ?? "Sort";
+  const isActive = sortItems.some((item) => item.value === currentRefinement);
 
   return (
     <DropdownMenu>
@@ -49,6 +55,14 @@ export default function MobileSortButton({ sortItems }: MobileSortButtonProps) {
             </DropdownMenuRadioItem>
           ))}
         </DropdownMenuRadioGroup>
+        {isActive && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => refine(baseIndex)}>
+              Clear sort
+            </DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/PlanSearch.tsx
+++ b/src/components/PlanSearch.tsx
@@ -72,6 +72,7 @@ function Stats() {
 }
 
 interface ResultsHeaderProps {
+  baseIndex: string;
   sortItems: SortItem[];
 }
 
@@ -82,6 +83,7 @@ interface ResultsHeaderFullProps extends ResultsHeaderProps {
 
 // Results Header component
 function ResultsHeader({
+  baseIndex,
   sortItems,
   viewMode,
   onViewModeChange,
@@ -91,14 +93,14 @@ function ResultsHeader({
       <div className="flex items-center justify-between gap-4 md:justify-start">
         <Stats />
         <div className="flex items-center gap-2 md:hidden">
-          <MobileSortButton sortItems={sortItems} />
+          <MobileSortButton baseIndex={baseIndex} sortItems={sortItems} />
           <MobileFilters />
         </div>
       </div>
       <div className="hidden items-center gap-3 md:flex">
         <SavedSearches />
         <ViewToggle onChange={onViewModeChange} value={viewMode} />
-        <CustomSortBy items={sortItems} />
+        <CustomSortBy baseIndex={baseIndex} items={sortItems} />
       </div>
     </div>
   );
@@ -314,6 +316,40 @@ function FiltersCard() {
   );
 }
 
+// Scrolls the most recently clicked plan card back into view when the user
+// returns to the search page from a plan detail.
+function ScrollRestorer() {
+  const { status, results } = useInstantSearch();
+  const attemptedRef = useRef(false);
+
+  useEffect(() => {
+    if (attemptedRef.current) {
+      return;
+    }
+    if (status !== "idle" || !results || results.hits.length === 0) {
+      return;
+    }
+    const planId = sessionStorage.getItem("pendingScrollToPlan");
+    if (!planId) {
+      return;
+    }
+
+    attemptedRef.current = true;
+    sessionStorage.removeItem("pendingScrollToPlan");
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const el = document.getElementById(planId);
+        if (el) {
+          el.scrollIntoView({ block: "center", behavior: "auto" });
+        }
+      });
+    });
+  }, [status, results]);
+
+  return null;
+}
+
 function SearchEventTracker() {
   const { indexUiState, results } = useInstantSearch();
   const { user } = useUser();
@@ -395,6 +431,7 @@ export default function PlanSearch({ indexName, sortItems }: PlanSearchProps) {
       stalledSearchDelay={500}
     >
       <SearchEventTracker />
+      <ScrollRestorer />
       <Container className="max-w-full">
         <div className="py-6">
           {/* Main Content Grid */}
@@ -416,6 +453,7 @@ export default function PlanSearch({ indexName, sortItems }: PlanSearchProps) {
               <div className="space-y-6">
                 <OnboardingBanner />
                 <ResultsHeader
+                  baseIndex={indexName}
                   onViewModeChange={handleViewModeChange}
                   sortItems={sortItems}
                   viewMode={viewMode}

--- a/src/components/ZoomableImage.tsx
+++ b/src/components/ZoomableImage.tsx
@@ -1,0 +1,114 @@
+import { Minus, Plus, RotateCcw } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+interface ZoomableImageProps {
+  alt: string;
+  src: string;
+}
+
+export default function ZoomableImage({ src, alt }: ZoomableImageProps) {
+  const [scale, setScale] = useState(1);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const isDragging = useRef(false);
+  const lastPos = useRef({ x: 0, y: 0 });
+
+  // Reset zoom/pan when the image source changes (multi-image galleries)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: src is intentionally the trigger for this reset effect
+  useEffect(() => {
+    setScale(1);
+    setPosition({ x: 0, y: 0 });
+  }, [src]);
+
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    setScale((s) => Math.min(5, Math.max(0.5, s - e.deltaY * 0.002)));
+  }, []);
+
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    isDragging.current = true;
+    lastPos.current = { x: e.clientX, y: e.clientY };
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent) => {
+    if (!isDragging.current) {
+      return;
+    }
+    const dx = e.clientX - lastPos.current.x;
+    const dy = e.clientY - lastPos.current.y;
+    lastPos.current = { x: e.clientX, y: e.clientY };
+    setPosition((p) => ({ x: p.x + dx, y: p.y + dy }));
+  }, []);
+
+  const handlePointerUp = useCallback(() => {
+    isDragging.current = false;
+  }, []);
+
+  const reset = useCallback(() => {
+    setScale(1);
+    setPosition({ x: 0, y: 0 });
+  }, []);
+
+  return (
+    <div className="relative h-full w-full overflow-hidden rounded-md">
+      {/* Image pan/zoom surface — fills all available space */}
+      <div
+        className="flex h-full w-full items-center justify-center"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onWheel={handleWheel}
+        style={{ cursor: scale > 1 ? "grab" : "default" }}
+      >
+        <img
+          alt={alt}
+          className="max-h-full max-w-full select-none object-contain"
+          draggable={false}
+          src={src}
+          style={{
+            transform: `translate(${position.x}px, ${position.y}px) scale(${scale})`,
+            transformOrigin: "center center",
+            transition: isDragging.current ? "none" : "transform 0.1s ease-out",
+          }}
+        />
+      </div>
+
+      {/* Floating zoom controls */}
+      <div className="absolute top-4 left-1/2 z-20 flex -translate-x-1/2 items-center gap-2 rounded-full border bg-background/85 px-2 py-1.5 shadow-lg backdrop-blur-sm">
+        <span className="w-12 text-center text-muted-foreground text-sm tabular-nums">
+          {Math.round(scale * 100)}%
+        </span>
+        <div className="flex items-center gap-0.5">
+          <Button
+            aria-label="Zoom out"
+            className="h-7 w-7"
+            onClick={() => setScale((s) => Math.max(0.5, s - 0.25))}
+            size="icon"
+            variant="ghost"
+          >
+            <Minus className="h-4 w-4" />
+          </Button>
+          <Button
+            aria-label="Zoom in"
+            className="h-7 w-7"
+            onClick={() => setScale((s) => Math.min(5, s + 0.25))}
+            size="icon"
+            variant="ghost"
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+          <Button
+            aria-label="Reset zoom"
+            className="h-7 w-7"
+            onClick={reset}
+            size="icon"
+            variant="ghost"
+          >
+            <RotateCcw className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -5,16 +5,13 @@ import {
   Calendar,
   Expand,
   GitCompareArrows,
-  Minus,
   ImageOff,
   Loader2,
   Play,
-  Plus,
-  RotateCcw,
   Trash2,
   X,
 } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import EmptyState from "@/components/EmptyState";
 import { Button } from "@/components/ui/button";
@@ -38,6 +35,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import ZoomableImage from "@/components/ZoomableImage";
 import { useComparison } from "@/hooks/use-comparison";
 import { useSavedComparisons } from "@/hooks/use-saved-comparisons";
 import { searchClient } from "@/lib/algolia";
@@ -86,94 +84,6 @@ const ATTRIBUTES: Array<{
   },
 ];
 
-function ZoomableImage({ src, alt }: { src: string; alt: string }) {
-  const [scale, setScale] = useState(1);
-  const [position, setPosition] = useState({ x: 0, y: 0 });
-  const isDragging = useRef(false);
-  const lastPos = useRef({ x: 0, y: 0 });
-
-  const handleWheel = useCallback((e: React.WheelEvent) => {
-    e.preventDefault();
-    setScale((s) => Math.min(5, Math.max(0.5, s - e.deltaY * 0.002)));
-  }, []);
-
-  const handlePointerDown = useCallback((e: React.PointerEvent) => {
-    isDragging.current = true;
-    lastPos.current = { x: e.clientX, y: e.clientY };
-    (e.target as HTMLElement).setPointerCapture(e.pointerId);
-  }, []);
-
-  const handlePointerMove = useCallback((e: React.PointerEvent) => {
-    if (!isDragging.current) return;
-    const dx = e.clientX - lastPos.current.x;
-    const dy = e.clientY - lastPos.current.y;
-    lastPos.current = { x: e.clientX, y: e.clientY };
-    setPosition((p) => ({ x: p.x + dx, y: p.y + dy }));
-  }, []);
-
-  const handlePointerUp = useCallback(() => {
-    isDragging.current = false;
-  }, []);
-
-  const reset = useCallback(() => {
-    setScale(1);
-    setPosition({ x: 0, y: 0 });
-  }, []);
-
-  return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-center justify-center gap-2">
-        <span className="w-12 text-center text-muted-foreground text-sm">
-          {Math.round(scale * 100)}%
-        </span>
-        <div className="flex items-center gap-1">
-          <Button
-            onClick={() => setScale((s) => Math.max(0.5, s - 0.25))}
-            size="icon"
-            variant="outline"
-          >
-            <Minus className="h-4 w-4" />
-          </Button>
-          <Button
-            onClick={() => setScale((s) => Math.min(5, s + 0.25))}
-            size="icon"
-            variant="outline"
-          >
-            <Plus className="h-4 w-4" />
-          </Button>
-          <Button onClick={reset} size="icon" variant="outline">
-            <RotateCcw className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-      <div
-        className="overflow-hidden rounded-md"
-        onWheel={handleWheel}
-        style={{ cursor: scale > 1 ? "grab" : "default" }}
-      >
-        <div
-          className="flex max-h-[78vh] items-center justify-center"
-          onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-          onPointerUp={handlePointerUp}
-        >
-          <img
-            alt={alt}
-            className="max-h-[78vh] w-full select-none object-contain"
-            draggable={false}
-            src={src}
-            style={{
-              transform: `translate(${position.x}px, ${position.y}px) scale(${scale})`,
-              transformOrigin: "center center",
-              transition: isDragging.current ? "none" : "transform 0.1s ease-out",
-            }}
-          />
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function ComparePlanImage({ src, alt }: { src?: string; alt: string }) {
   const [imageError, setImageError] = useState(false);
   const [enlarged, setEnlarged] = useState(false);
@@ -205,11 +115,11 @@ function ComparePlanImage({ src, alt }: { src?: string; alt: string }) {
         </div>
       </button>
       <Dialog onOpenChange={setEnlarged} open={enlarged}>
-        <DialogContentNoClose className="max-h-[90vh] max-w-[90vw] p-4">
+        <DialogContentNoClose className="flex h-[90vh] max-h-[90vh] w-[90vw] max-w-[90vw] flex-col p-4">
           <DialogHeader className="sr-only">
             <DialogTitle>{alt}</DialogTitle>
           </DialogHeader>
-          <div className="flex items-center justify-between">
+          <div className="mb-2 flex items-center justify-between">
             <span className="font-medium text-sm">{alt}</span>
             <DialogClose asChild>
               <Button size="icon" variant="outline">
@@ -217,7 +127,9 @@ function ComparePlanImage({ src, alt }: { src?: string; alt: string }) {
               </Button>
             </DialogClose>
           </div>
-          <ZoomableImage alt={alt} src={src} />
+          <div className="min-h-0 flex-1">
+            <ZoomableImage alt={alt} src={src} />
+          </div>
         </DialogContentNoClose>
       </Dialog>
     </>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,7 +2,6 @@ import PlanSearch from "@/components/PlanSearch";
 import type { SortItem } from "@/types/floor-plan";
 
 const sortItems: SortItem[] = [
-  { label: "Default", value: "floorPlans" },
   { label: "Newest", value: "floorPlans_dateAdded_desc" },
   { label: "Oldest", value: "floorPlans_dateAdded_asc" },
   { label: "Bedrooms (asc)", value: "floorPlans_bedrooms_asc" },

--- a/src/pages/Master.tsx
+++ b/src/pages/Master.tsx
@@ -4,7 +4,6 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { SortItem } from "@/types/floor-plan";
 
 const allPlansSortItems: SortItem[] = [
-  { label: "Default", value: "allPlans" },
   { label: "Newest", value: "allPlans_dateAdded_desc" },
   { label: "Oldest", value: "allPlans_dateAdded_asc" },
   { label: "Bedrooms (asc)", value: "allPlans_bedrooms_asc" },
@@ -16,7 +15,6 @@ const allPlansSortItems: SortItem[] = [
 ];
 
 const publishedSortItems: SortItem[] = [
-  { label: "Default", value: "floorPlans" },
   { label: "Newest", value: "floorPlans_dateAdded_desc" },
   { label: "Oldest", value: "floorPlans_dateAdded_asc" },
   { label: "Bedrooms (asc)", value: "floorPlans_bedrooms_asc" },

--- a/src/pages/PlanDetail.tsx
+++ b/src/pages/PlanDetail.tsx
@@ -4,6 +4,7 @@ import { motion, useReducedMotion } from "framer-motion";
 import {
   AlertCircle,
   ArrowDownToLine,
+  ArrowLeft,
   ArrowUpFromLine,
   Car,
   ChevronRight,
@@ -15,7 +16,7 @@ import {
   Ruler,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import CompareButton from "@/components/CompareButton";
 import FavoriteButton from "@/components/FavoriteButton";
 import ImageGallery from "@/components/ImageGallery";
@@ -183,9 +184,15 @@ function getFeaturePills(hit: FloorPlanHit) {
 
 export default function PlanDetail() {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
   const { data, isLoading, error, refetch } = usePlanData(id);
   const [downloading, setDownloading] = useState(false);
   const [stickyVisible, setStickyVisible] = useState(false);
+
+  const handleBackToSearch = useCallback(() => {
+    const lastSearchUrl = sessionStorage.getItem("lastSearchUrl");
+    navigate(lastSearchUrl ?? "/");
+  }, [navigate]);
 
   const { user } = useUser();
   const trackViewMutation = useMutation(api.analytics.trackView);
@@ -356,6 +363,17 @@ export default function PlanDetail() {
         initial={prefersReducedMotion ? false : { opacity: 0, y: 12 }}
         transition={{ duration: 0.3, ease: "easeOut" }}
       >
+        {/* Back to search results */}
+        <Button
+          className="mb-3 -ml-3 h-auto px-3 py-1.5 text-muted-foreground hover:text-foreground"
+          onClick={handleBackToSearch}
+          size="sm"
+          variant="ghost"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Search Results
+        </Button>
+
         {/* Breadcrumb */}
         <nav aria-label="Breadcrumb" className="mb-6">
           <ol className="flex flex-wrap items-center gap-1.5 text-muted-foreground text-sm">


### PR DESCRIPTION
## Summary
- Extract shared `ZoomableImage` component used by both Compare view and `ImageGallery` lightbox
- Refine search UI controls: pagination, range inputs, and sort for visual/behavioral consistency
- Misc tweaks across `FloorPlanCard`, `ListHits`, `MobileSortButton`, `PlanSearch`, `PlanDetail`

## Test plan
- [ ] Verify zoom/pan works in `ImageGallery` lightbox
- [ ] Verify zoom/pan works in the Compare page
- [ ] Spot-check pagination, range filters, and sort behavior on Home and Master search pages
- [ ] Confirm mobile sort button still works on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)